### PR TITLE
Concurrency Added & Print Removed PR tests:

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,6 @@ require (
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/google/uuid v1.6.0
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jmoiron/sqlx v1.4.0 // indirect
+	github.com/jmoiron/sqlx v1.4.0
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,12 +11,14 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
 github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=

--- a/schemas/db_schema.go
+++ b/schemas/db_schema.go
@@ -1,12 +1,15 @@
 package schemas
 
+import "sync"
+
 type DbStore interface {
 	Setup() error
 	UseDatabase(name string) error
 	GetTableFields(database, table string) ([]TableFields, error)
 	GenerateInsertionMap(fields []TableFields, seedSize int64) []map[string]InsertionMap
-	BatchInsertFromMap(bArr []map[string]InsertionMap, fields []TableFields, table string, chunkSize int64) error
-	SelectCount(table string) (int64, error)
+	BatchInsertFromMap(bArr []map[string]InsertionMap, fields []TableFields, table string, chunkSize int64, dbName string, maxConn int, wg *sync.WaitGroup) error
+	SelectCount(table string, dbName string) (int64, error)
+	GetMaxConnections() (int, error)
 }
 
 type TableFields struct {
@@ -25,4 +28,8 @@ type InsertionMap struct {
 
 type NumberNil interface {
 	Number() int64
+}
+type ShowVariables struct {
+	Variable_name string `db:"Variable_name"`
+	Value         string `db:"Value"`
 }

--- a/todo.md
+++ b/todo.md
@@ -30,14 +30,20 @@ Creating intermediate string for each loop, it took ~660ms
 Generating SQL Value Strings for 1M rows: ~17s
 After optimizing by making a  tmpSlice instead of a tmpString and just concatenating when the chunkSize is met and then cleaning the tmpArray, it took: ~5s
 
-Change: Multithreading
-    -> Before: 1M rows, 1k chunkSize, it took ~18s
-    -> After: 1M rows, 1k chunkSize, it took ~11s
-CHange: Removing useless fmt.Println
-    -> Before: 1M rows, 1k chunkSize, it took ~11s
-    -> After: 1M rows, 1k chunkSize, it took ~5s
 TODO: Add more types
 TODO: Support for composite primary keys
 TODO: Support for foreign keys
 TODO: Make batch insert for each chunkSize
 
+Concurrency Added & Print Removed PR tests:
+After PR:
+    -> 1M rows, 100 chunkSize, it took ~9.7s
+    -> 1M rows, 1k chunkSize, it took ~8.3s
+    -> 1M rows, 10k chunkSize, it took ~8.2s
+    -> 1M rows, 100k chunkSize, it took ~15.6s
+
+Before PR:
+    -> 1M rows, 100 chunkSize, it took ~39.4s
+    -> 1M rows, 1k chunkSize, it took ~22.8s
+    -> 1M rows, 10k chunkSize, it took ~19.3s
+    -> 1M rows, 100k chunkSize, it took ~19.6s

--- a/todo.md
+++ b/todo.md
@@ -31,6 +31,8 @@ Generating SQL Value Strings for 1M rows: ~17s
 After optimizing by making a  tmpSlice instead of a tmpString and just concatenating when the chunkSize is met and then cleaning the tmpArray, it took: ~5s
 
 TODO: Multithreading
+    -> Before: 1M rows, 1k chunkSize, it took ~18s
+    -> After: 1M rows, 1k chunkSize, it took ~11s
 TODO: Add more types
 TODO: Support for composite primary keys
 TODO: Support for foreign keys

--- a/todo.md
+++ b/todo.md
@@ -30,10 +30,14 @@ Creating intermediate string for each loop, it took ~660ms
 Generating SQL Value Strings for 1M rows: ~17s
 After optimizing by making a  tmpSlice instead of a tmpString and just concatenating when the chunkSize is met and then cleaning the tmpArray, it took: ~5s
 
-TODO: Multithreading
+Change: Multithreading
     -> Before: 1M rows, 1k chunkSize, it took ~18s
     -> After: 1M rows, 1k chunkSize, it took ~11s
+CHange: Removing useless fmt.Println
+    -> Before: 1M rows, 1k chunkSize, it took ~11s
+    -> After: 1M rows, 1k chunkSize, it took ~5s
 TODO: Add more types
 TODO: Support for composite primary keys
 TODO: Support for foreign keys
 TODO: Make batch insert for each chunkSize
+


### PR DESCRIPTION
# Changes:

### Changes to BatchInsertFromMap:

- Changed algorithm to INSERT batch when array meets chunkSize, instead of saving to slice.
- Added GO routines to INSERT lock the SQL string builder generation
- Added Wait Group to wait for all INSERTS to conclude
- Added Channels to limit the number of GO routines for the configured database max connections
- Removed Printf calls from the inside of loops.

### Lazy Benchmarks
- 1M rows, 100 chunkSize: 39.4s -> 9.7s
- 1M rows, 1k chunkSize:22.8s -> 8.3s
- 1M rows, 10k chunkSize: 19.3s -> 8.2s
- 1M rows, 100k chunkSize: 19.6s -> 15.6s

The bigger the difference from the numbers of rows inserted compared to the chunkSize, the bigger the difference on performance with this change.